### PR TITLE
fix: Clean up temporary files after compression and save

### DIFF
--- a/package/cpp/FileUtils.cpp
+++ b/package/cpp/FileUtils.cpp
@@ -1,0 +1,17 @@
+#include "FileUtils.hpp"
+
+namespace margelo::nitro::imagecompressor {
+  std::string FileUtils::stripFilePrefix(const std::string& path) {
+    if (path.find("file://") == 0) {
+      return path.substr(7);
+    }
+    return path;
+  }
+
+  void FileUtils::removeTmpFile(const std::string& path) {
+    std::string strippedPath = stripFilePrefix(path);
+    if (std::filesystem::exists(strippedPath)) {
+      std::filesystem::remove(strippedPath);
+    }
+  }
+} // namespace margelo::nitro::imagecompressor

--- a/package/cpp/FileUtils.hpp
+++ b/package/cpp/FileUtils.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <filesystem>
+
+namespace margelo::nitro::imagecompressor {
+  class FileUtils {
+  public:
+    static std::string stripFilePrefix(const std::string& path);
+    static void removeTmpFile(const std::string& path);
+  };
+} // namespace margelo::nitro::imagecompressor

--- a/package/cpp/HybridCompressedImageAsset.cpp
+++ b/package/cpp/HybridCompressedImageAsset.cpp
@@ -8,6 +8,9 @@ namespace margelo::nitro::imagecompressor {
 
 #if __has_include("ImageCompressor-Swift.h")
     bool result = ImageCompressor::saveImageToPhotos(_uri);
+    if (result) {
+      FileUtils::removeTmpFile(_uri);
+    }
     promise->resolve(result);
     return promise;
 #else
@@ -17,9 +20,14 @@ namespace margelo::nitro::imagecompressor {
 
 #else // If on Android
     bool result = ImageCompressor_jni::saveImageToPhotos(_uri);
+    if (result) {
+      FileUtils::removeTmpFile(_uri);
+    }
     promise->resolve(result);
     return promise;
 
 #endif // end ifdef __APPLE__
   }
+
 } // namespace margelo::nitro::imagecompressor
+

--- a/package/cpp/HybridCompressedImageAsset.hpp
+++ b/package/cpp/HybridCompressedImageAsset.hpp
@@ -3,6 +3,8 @@
 
 #include "HybridCompressedImageAssetSpec.hpp"
 #include <string>
+#include <filesystem>
+#include "FileUtils.hpp"
 
 #ifdef __APPLE__ // If on iOS
 #if __has_include("ImageCompressor-Swift.h")

--- a/package/cpp/HybridImageCompressor.cpp
+++ b/package/cpp/HybridImageCompressor.cpp
@@ -12,6 +12,7 @@ namespace margelo::nitro::imagecompressor {
 
   std::shared_ptr<margelo::nitro::imagecompressor::HybridCompressedImageAssetSpec>
   HybridImageCompressor::compress(const ImageAsset& image, const std::optional<CompressionOptions>& options) {
+    FileUtils::removeTmpFile(tmpImagePath);
     auto result = ImageUtils::compressImage(image, options);
     tmpImagePath = result.get()->getUri(); // Store the path for later use
     return result;

--- a/package/cpp/HybridImageCompressor.hpp
+++ b/package/cpp/HybridImageCompressor.hpp
@@ -2,6 +2,7 @@
 
 #include "HybridImageCompressorSpec.hpp"
 #include <string>
+#include "FileUtils.hpp"
 
 namespace margelo::nitro::imagecompressor {
   class HybridImageCompressor : public HybridImageCompressorSpec {

--- a/package/cpp/ImageUtils.cpp
+++ b/package/cpp/ImageUtils.cpp
@@ -5,13 +5,6 @@
 
 namespace margelo::nitro::imagecompressor {
 
-  std::string ImageUtils::stripFilePrefix(const std::string& path) {
-    if (path.find("file://") == 0) {
-      return path.substr(7);
-    }
-    return path;
-  }
-
   cv::Mat ImageUtils::loadImage(const std::string& path) {
     cv::Mat img = cv::imread(path);
     if (img.empty()) {
@@ -98,7 +91,7 @@ namespace margelo::nitro::imagecompressor {
     auto opts = options.value_or(CompressionOptions(
         std::optional<double>(0.8), std::nullopt, std::nullopt, std::optional<std::string>("jpg")));
 
-    std::string path = stripFilePrefix(image.uri);
+    std::string path = FileUtils::stripFilePrefix(image.uri);
     cv::Mat img = loadImage(path);
     cv::Mat resizedImg = resizeImage(img, opts.maxWidth, opts.maxHeight);
     img = preprocessImg(resizedImg);

--- a/package/cpp/ImageUtils.hpp
+++ b/package/cpp/ImageUtils.hpp
@@ -6,6 +6,7 @@
 #include <filesystem>
 #include <opencv2/opencv.hpp>
 #include <string>
+#include "FileUtils.hpp"
 
 namespace margelo::nitro::imagecompressor {
 
@@ -16,7 +17,6 @@ namespace margelo::nitro::imagecompressor {
     compressImage(const ImageAsset& image, const std::optional<CompressionOptions>& options);
 
     // Helper functions
-    static std::string stripFilePrefix(const std::string& path);
     static std::string formatFileSize(uintmax_t bytes);
 
   private:


### PR DESCRIPTION
This PR takes care of temporary file handling by:
- Cleaning up temporary files after successful save to photo library
- Deleting previous temporary file before new compression

This prevents accumulating temporary files on the device.

Closes #14 